### PR TITLE
Add skeleton Next.js app with virtualized finance pages

### DIFF
--- a/components/BulkImportModal.tsx
+++ b/components/BulkImportModal.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+import Papa from 'papaparse';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onData: (rows: any[]) => void;
+}
+
+export default function BulkImportModal({ isOpen, onClose, onData }: Props) {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    if (isOpen) window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleFile = (file: File) => {
+    Papa.parse(file, {
+      header: true,
+      complete: results => onData(results.data as any[]),
+      error: err => setError(err.message)
+    });
+  };
+
+  const handlePaste = () => {
+    const text = textAreaRef.current?.value || '';
+    const rows = text
+      .trim()
+      .split('\n')
+      .map(line => line.split('\t'));
+    onData(rows);
+  };
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <h2>Bulk Paste / CSV Import</h2>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        <textarea ref={textAreaRef} placeholder="Paste tab-separated values here" rows={10} style={{ width: '100%' }} />
+        <div>
+          <input
+            type="file"
+            accept=".csv"
+            onChange={e => e.target.files && handleFile(e.target.files[0])}
+          />
+          <button onClick={handlePaste}>Import</button>
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/CurrencySwitcher.tsx
+++ b/components/CurrencySwitcher.tsx
@@ -1,0 +1,16 @@
+import { useCurrency } from '../contexts/CurrencyContext';
+
+const currencies = ['USD', 'EUR', 'VND'];
+
+export default function CurrencySwitcher() {
+  const { currency, setCurrency } = useCurrency();
+  return (
+    <select value={currency} onChange={e => setCurrency(e.target.value)} style={{ marginLeft: '1rem' }}>
+      {currencies.map(c => (
+        <option key={c} value={c}>
+          {c}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -1,0 +1,10 @@
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function ThemeSwitcher() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button onClick={toggleTheme} style={{ marginLeft: '1rem' }}>
+      {theme === 'light' ? '🌞' : '🌙'}
+    </button>
+  );
+}

--- a/components/VirtualizedTable.tsx
+++ b/components/VirtualizedTable.tsx
@@ -1,0 +1,75 @@
+import { FixedSizeList as List } from 'react-window';
+import { useEffect, useState } from 'react';
+import BulkImportModal from './BulkImportModal';
+
+interface Row {
+  id: number | string;
+  [key: string]: any;
+}
+
+interface Props {
+  columns: string[];
+  rows: Row[];
+  onSave: (rows: Row[]) => void;
+}
+
+export default function VirtualizedTable({ columns, rows, onSave }: Props) {
+  const [data, setData] = useState<Row[]>(rows);
+  const [showImport, setShowImport] = useState(false);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Enter') onSave(data);
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        onSave(data);
+      }
+      if (e.key === 'Escape') setShowImport(false);
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [data, onSave]);
+
+  const RowRenderer = ({ index, style }: { index: number; style: any }) => (
+    <div
+      style={{
+        ...style,
+        display: 'flex',
+        backgroundColor: index % 2 === 0 ? '#f9f9f9' : '#fff',
+        padding: '0 8px'
+      }}
+    >
+      {columns.map(col => (
+        <div key={col} style={{ flex: 1 }}>
+          {data[index][col] ?? ''}
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div>
+      <div style={{ position: 'sticky', top: 0, background: '#ddd', display: 'flex', padding: '0 8px' }}>
+        {columns.map(col => (
+          <div key={col} style={{ flex: 1 }}>
+            {col}
+          </div>
+        ))}
+        <button onClick={() => setShowImport(true)} style={{ marginLeft: 'auto' }}>
+          Import
+        </button>
+      </div>
+      <List height={300} itemCount={data.length} itemSize={35} width={'100%'}>
+        {RowRenderer}
+      </List>
+      <BulkImportModal
+        isOpen={showImport}
+        onClose={() => setShowImport(false)}
+        onData={rows => {
+          setData(rows.map((r, i) => ({ id: i, ...r } as Row)));
+          setShowImport(false);
+        }}
+      />
+    </div>
+  );
+}

--- a/contexts/CurrencyContext.tsx
+++ b/contexts/CurrencyContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, useState } from 'react';
+
+interface CurrencyContextProps {
+  currency: string;
+  setCurrency: (c: string) => void;
+}
+
+const CurrencyContext = createContext<CurrencyContextProps | undefined>(undefined);
+
+export const CurrencyProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [currency, setCurrency] = useState('USD');
+  return <CurrencyContext.Provider value={{ currency, setCurrency }}>{children}</CurrencyContext.Provider>;
+};
+
+export const useCurrency = () => {
+  const ctx = useContext(CurrencyContext);
+  if (!ctx) throw new Error('useCurrency must be used within CurrencyProvider');
+  return ctx;
+};

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextProps {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextProps | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    document.body.dataset.theme = theme;
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => (t === 'light' ? 'dark' : 'light'));
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ad-finance-manager",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo 'No tests specified' && exit 0"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-window": "1.8.7",
+    "papaparse": "5.4.1"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,22 @@
+import type { AppProps } from 'next/app';
+import '../styles/global.css';
+import { ThemeProvider } from '../contexts/ThemeContext';
+import { CurrencyProvider } from '../contexts/CurrencyContext';
+import ThemeSwitcher from '../components/ThemeSwitcher';
+import CurrencySwitcher from '../components/CurrencySwitcher';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ThemeProvider>
+      <CurrencyProvider>
+        <div style={{ padding: '1rem' }}>
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <CurrencySwitcher />
+            <ThemeSwitcher />
+          </div>
+          <Component {...pageProps} />
+        </div>
+      </CurrencyProvider>
+    </ThemeProvider>
+  );
+}

--- a/pages/ad-accounts/[id]/mappings.tsx
+++ b/pages/ad-accounts/[id]/mappings.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router';
+import VirtualizedTable from '../../../components/VirtualizedTable';
+
+const columns = ['id', 'mapping'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, mapping: `Mapping ${i}` }));
+
+export default function AdAccountMappings() {
+  const { query } = useRouter();
+  return (
+    <div>
+      <h1>Ad Account {query.id} Mappings</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/ad-accounts/index.tsx
+++ b/pages/ad-accounts/index.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../../components/VirtualizedTable';
+
+const columns = ['id', 'account'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, account: `Account ${i}` }));
+
+export default function AdAccounts() {
+  return (
+    <div>
+      <h1>Ad Accounts</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/bank-accounts.tsx
+++ b/pages/bank-accounts.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'account'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, account: `Account ${i}` }));
+
+export default function BankAccounts() {
+  return (
+    <div>
+      <h1>Bank Accounts</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/banks.tsx
+++ b/pages/banks.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'bank'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, bank: `Bank ${i}` }));
+
+export default function Banks() {
+  return (
+    <div>
+      <h1>Banks</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/cards.tsx
+++ b/pages/cards.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'card'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, card: `Card ${i}` }));
+
+export default function Cards() {
+  return (
+    <div>
+      <h1>Cards</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/clients/[id].tsx
+++ b/pages/clients/[id].tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router';
+import VirtualizedTable from '../../components/VirtualizedTable';
+
+const columns = ['id', 'detail'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, detail: `Detail ${i}` }));
+
+export default function ClientDetail() {
+  const { query } = useRouter();
+  return (
+    <div>
+      <h1>Client {query.id}</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/clients/index.tsx
+++ b/pages/clients/index.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../../components/VirtualizedTable';
+
+const columns = ['id', 'client'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, client: `Client ${i}` }));
+
+export default function Clients() {
+  return (
+    <div>
+      <h1>Clients</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'name'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, name: `Item ${i}` }));
+
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/deposits.tsx
+++ b/pages/deposits.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'deposit'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, deposit: `Deposit ${i}` }));
+
+export default function Deposits() {
+  return (
+    <div>
+      <h1>Deposits</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Home() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/dashboard');
+  }, [router]);
+  return null;
+}

--- a/pages/invoices.tsx
+++ b/pages/invoices.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'invoice'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, invoice: `Invoice ${i}` }));
+
+export default function Invoices() {
+  return (
+    <div>
+      <h1>Invoices</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,12 @@
+export default function Login() {
+  return (
+    <div>
+      <h1>Login</h1>
+      <form>
+        <input type="text" placeholder="Username" />
+        <input type="password" placeholder="Password" />
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/logs.tsx
+++ b/pages/logs.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'log'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, log: `Log ${i}` }));
+
+export default function Logs() {
+  return (
+    <div>
+      <h1>Logs</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/reconcile.tsx
+++ b/pages/reconcile.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'reconcile'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, reconcile: `Reconcile ${i}` }));
+
+export default function Reconcile() {
+  return (
+    <div>
+      <h1>Reconcile</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'setting'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, setting: `Setting ${i}` }));
+
+export default function Settings() {
+  return (
+    <div>
+      <h1>Settings</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/pages/statements.tsx
+++ b/pages/statements.tsx
@@ -1,0 +1,13 @@
+import VirtualizedTable from '../components/VirtualizedTable';
+
+const columns = ['id', 'statement'];
+const rows = Array.from({ length: 1000 }).map((_, i) => ({ id: i, statement: `Statement ${i}` }));
+
+export default function Statements() {
+  return (
+    <div>
+      <h1>Statements</h1>
+      <VirtualizedTable columns={columns} rows={rows} onSave={r => console.log('save', r.length)} />
+    </div>
+  );
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,0 +1,25 @@
+body[data-theme='dark'] {
+  background: #222;
+  color: #eee;
+}
+body[data-theme='light'] {
+  background: #fff;
+  color: #000;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-content {
+  background: white;
+  padding: 1rem;
+  max-width: 500px;
+  width: 100%;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js structure with theme and currency providers
- implement virtualized tables with bulk import modal and keyboard shortcuts
- add placeholder pages for login, dashboard, clients, ad accounts, and more

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad43027b4c83268ec30bae1fac290a