### PR TITLE
Add CRUD API routes for clients and ad accounts with validation

### DIFF
--- a/app/api/ad-accounts/[id]/route.ts
+++ b/app/api/ad-accounts/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { adAccountSchema } from '../../../../lib/validators';
+import { adAccounts } from '../../../../lib/data';
+
+interface Params { params: { id: string } }
+
+export async function GET(_req: Request, { params }: Params) {
+  const adAccount = adAccounts.find(a => a.id === params.id);
+  if (!adAccount) return NextResponse.json({ error: 'Ad account not found' }, { status: 404 });
+  return NextResponse.json(adAccount);
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  try {
+    const body = await req.json();
+    const data = adAccountSchema.partial().parse(body);
+    const index = adAccounts.findIndex(a => a.id === params.id);
+    if (index === -1) return NextResponse.json({ error: 'Ad account not found' }, { status: 404 });
+    adAccounts[index] = { ...adAccounts[index], ...data };
+    return NextResponse.json(adAccounts[index]);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const index = adAccounts.findIndex(a => a.id === params.id);
+  if (index === -1) return NextResponse.json({ error: 'Ad account not found' }, { status: 404 });
+  const [deleted] = adAccounts.splice(index, 1);
+  return NextResponse.json(deleted);
+}

--- a/app/api/ad-accounts/route.ts
+++ b/app/api/ad-accounts/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { adAccountSchema } from '../../../lib/validators';
+import { adAccounts } from '../../../lib/data';
+
+export async function GET() {
+  return NextResponse.json(adAccounts);
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const data = adAccountSchema.parse(body);
+    const adAccount = { id: crypto.randomUUID(), ...data };
+    adAccounts.push(adAccount);
+    return NextResponse.json(adAccount, { status: 201 });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 400 });
+  }
+}

--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { clientSchema } from '../../../../lib/validators';
+import { clients } from '../../../../lib/data';
+
+interface Params { params: { id: string } }
+
+export async function GET(_req: Request, { params }: Params) {
+  const client = clients.find(c => c.id === params.id);
+  if (!client) return NextResponse.json({ error: 'Client not found' }, { status: 404 });
+  return NextResponse.json(client);
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  try {
+    const body = await req.json();
+    const data = clientSchema.partial().parse(body);
+    const index = clients.findIndex(c => c.id === params.id);
+    if (index === -1) return NextResponse.json({ error: 'Client not found' }, { status: 404 });
+    clients[index] = { ...clients[index], ...data };
+    return NextResponse.json(clients[index]);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const index = clients.findIndex(c => c.id === params.id);
+  if (index === -1) return NextResponse.json({ error: 'Client not found' }, { status: 404 });
+  const [deleted] = clients.splice(index, 1);
+  return NextResponse.json(deleted);
+}

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { clientSchema } from '../../../lib/validators';
+import { clients } from '../../../lib/data';
+
+export async function GET() {
+  return NextResponse.json(clients);
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const data = clientSchema.parse(body);
+    const client = { id: crypto.randomUUID(), ...data };
+    clients.push(client);
+    return NextResponse.json(client, { status: 201 });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 400 });
+  }
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,4 @@
+import type { Client, AdAccount } from './validators';
+
+export const clients: Client[] = [];
+export const adAccounts: AdAccount[] = [];

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const clientSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+});
+
+export type Client = z.infer<typeof clientSchema> & { id: string };
+
+export const adAccountSchema = z.object({
+  internalId: z.string(),
+  fbAdAccountId: z.string(),
+  status: z.string(),
+  accountCurrency: z.string(),
+  cardFeeDecimal: z.number(),
+});
+
+export type AdAccount = z.infer<typeof adAccountSchema> & { id: string };


### PR DESCRIPTION
## Summary
- add Zod schemas for clients and ad accounts
- implement GET/POST/PATCH/DELETE handlers for clients and ad accounts
- provide in-memory data store

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad42fe26dc8326a73fda8bd6c0b5fb