### PR TITLE
Configure next-pwa in Next.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,27 @@
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  disable: process.env.NODE_ENV === 'development',
+  register: true,
+  skipWaiting: true,
+  runtimeCaching: [
+    {
+      urlPattern: /^(https?):\/\/.*$/,
+      handler: 'NetworkFirst',
+      options: {
+        cacheName: 'http-cache',
+        networkTimeoutSeconds: 15,
+        expiration: {
+          maxEntries: 200,
+          maxAgeSeconds: 24 * 60 * 60,
+        },
+        cacheableResponse: {
+          statuses: [0, 200],
+        },
+      },
+    },
+  ],
+});
+
+module.exports = withPWA({
+  reactStrictMode: true,
+});


### PR DESCRIPTION
## Summary
- integrate next-pwa via `const withPWA = require('next-pwa')({...})`
- define inline runtime caching and basic options without generating binary assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad569ff118832699c25335274e0187