### PR TITLE
feat: convert app to TypeScript

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,14 @@
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+import InstallButton from '../components/InstallButton';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <header>
+        <InstallButton />
+      </header>
+      <Component {...pageProps} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Migrate Next.js custom App to TypeScript
- Render InstallButton in header while keeping global styles import

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad569f2dd88326b12dd71060364eea