### PR TITLE
Convert InstallButton to TypeScript

### DIFF
--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from "react";
+
+function InstallButton() {
+  const [prompt, setPrompt] = useState<Event | null>(null);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      setPrompt(e);
+    };
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+    };
+  }, []);
+
+  const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    (prompt as any)?.prompt?.();
+  };
+
+  if (!prompt) {
+    return null;
+  }
+
+  return <button onClick={onClick}>Install</button>;
+}
+
+export default InstallButton;


### PR DESCRIPTION
## Summary
- rename InstallButton component to TypeScript
- add typed install prompt state and onClick handler

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad569ea4588326ac78f956335beb9b