### PR TITLE
Initialize Next.js scaffold with Tailwind, shadcn/ui and Prisma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+.next
+dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# ad-finance-manager
-Khởi tạo repo để dùng với ChatGPT Codex.
+# Ad Finance Manager
+
+This is a scaffolded Next.js (App Router) project with Tailwind CSS, shadcn/ui components, and Prisma.
+
+## Getting Started
+
+Create a `.env` file in the project root and define:
+
+```
+DATABASE_URL="postgresql://user:password@localhost:5432/dbname"
+JWT_SECRET="your_jwt_secret"
+FB_API_VERSION="v19.0"
+```
+
+Then run the following commands:
+
+```
+npm i
+npx prisma migrate dev
+npm run seed
+npm run dev
+```
+
+The app will be available at http://localhost:3000.

--- a/app/api/ad-accounts/[id]/route.ts
+++ b/app/api/ad-accounts/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '../../../../lib/prisma';
+import { getUserId } from '../../../../lib/auth';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const account = await prisma.adAccount.findUnique({ where: { id: Number(params.id) } });
+  return NextResponse.json(account);
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { name, clientId } = await req.json();
+  const account = await prisma.adAccount.update({ where: { id: Number(params.id) }, data: { name, clientId } });
+  return NextResponse.json(account);
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  await prisma.adAccount.delete({ where: { id: Number(params.id) } });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/ad-accounts/route.ts
+++ b/app/api/ad-accounts/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '../../../lib/prisma';
+import { getUserId } from '../../../lib/auth';
+
+export async function GET(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const accounts = await prisma.adAccount.findMany();
+  return NextResponse.json(accounts);
+}
+
+export async function POST(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { name, clientId } = await req.json();
+  const account = await prisma.adAccount.create({ data: { name, clientId } });
+  return NextResponse.json(account);
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '../../../../lib/prisma';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user || !(await bcrypt.compare(password, user.password))) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+  }
+  const token = jwt.sign({ sub: user.id }, process.env.JWT_SECRET!, { expiresIn: '7d' });
+  const res = NextResponse.json({ success: true });
+  res.cookies.set('token', token, { httpOnly: true, path: '/' });
+  return res;
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const res = NextResponse.json({ success: true });
+  res.cookies.set('token', '', { httpOnly: true, path: '/', maxAge: 0 });
+  return res;
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '../../../../lib/prisma';
+import bcrypt from 'bcryptjs';
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    return NextResponse.json({ error: 'User already exists' }, { status: 400 });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  const user = await prisma.user.create({ data: { email, password: hashed } });
+  return NextResponse.json({ id: user.id, email: user.email });
+}

--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '../../../../lib/prisma';
+import { getUserId } from '../../../../lib/auth';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const client = await prisma.client.findUnique({ where: { id: Number(params.id) } });
+  return NextResponse.json(client);
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { name } = await req.json();
+  const client = await prisma.client.update({ where: { id: Number(params.id) }, data: { name } });
+  return NextResponse.json(client);
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  await prisma.client.delete({ where: { id: Number(params.id) } });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '../../../lib/prisma';
+import { getUserId } from '../../../lib/auth';
+
+export async function GET(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const clients = await prisma.client.findMany();
+  return NextResponse.json(clients);
+}
+
+export async function POST(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { name } = await req.json();
+  const client = await prisma.client.create({ data: { name } });
+  return NextResponse.json(client);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,33 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import '../src/styles/tailwind.css';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('theme');
+    if (stored) setTheme(stored);
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    window.localStorage.setItem('theme', next);
+  };
+
+  return (
+    <html lang="en" className={theme}>
+      <body className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <header className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+          <h1 className="font-bold">Ad Manager</h1>
+          <div className="space-x-2">
+            <button onClick={toggleTheme} className="px-2 py-1 border rounded">Toggle Theme</button>
+            <button className="px-2 py-1 border rounded">Install App</button>
+          </div>
+        </header>
+        <main className="p-4">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Dashboard</h2>
+      <p>Welcome to the ad account manager demo.</p>
+    </div>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-600 text-white hover:bg-blue-500',
+        secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300',
+        outline: 'border border-gray-200 hover:bg-gray-100',
+        ghost: 'hover:bg-gray-100',
+        link: 'underline-offset-4 hover:underline text-blue-600',
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 px-3 rounded-md',
+        lg: 'h-11 px-8 rounded-md',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn } from '../../lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/50 backdrop-blur-sm',
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-lg focus:outline-none',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-gray-500', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+};

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="w-full overflow-auto">
+      <table
+        ref={ref}
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  )
+);
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+  )
+);
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody
+      ref={ref}
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  )
+);
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot
+      ref={ref}
+      className={cn('bg-gray-50 font-medium text-gray-900', className)}
+      {...props}
+    />
+  )
+);
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn('border-b transition-colors hover:bg-gray-100', className)}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn('h-12 px-4 text-left align-middle font-medium text-gray-500', className)}
+      {...props}
+    />
+  )
+);
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td
+      ref={ref}
+      className={cn('p-4 align-middle', className)}
+      {...props}
+    />
+  )
+);
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => (
+    <caption
+      ref={ref}
+      className={cn('mt-4 text-sm text-gray-500', className)}
+      {...props}
+    />
+  )
+);
+TableCaption.displayName = 'TableCaption';
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+};

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from 'next/server';
+import jwt from 'jsonwebtoken';
+
+export function getUserId(req: NextRequest): number | null {
+  const token = req.cookies.get('token')?.value;
+  if (!token) return null;
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET!);
+    if (typeof payload === 'string') return parseInt(payload);
+    return (payload as any).sub as number;
+  } catch {
+    return null;
+  }
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client';
+
+declare global {
+  var prisma: PrismaClient | undefined;
+}
+
+const prisma = global.prisma || new PrismaClient();
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma;
+
+export default prisma;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "ad-account-manager",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "prisma:migrate": "prisma migrate dev",
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "engines": {
+    "node": ">=18.18"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "tailwindcss": "latest",
+    "postcss": "latest",
+    "autoprefixer": "latest",
+    "prisma": "latest",
+    "@prisma/client": "latest",
+    "bcryptjs": "latest",
+    "jsonwebtoken": "latest",
+    "class-variance-authority": "latest",
+    "@radix-ui/react-slot": "latest",
+    "@radix-ui/react-dialog": "latest",
+    "clsx": "latest",
+    "tailwind-merge": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "eslint": "latest",
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "ts-node": "latest"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,180 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+  clients   Client[]
+}
+
+model Client {
+  id        Int        @id @default(autoincrement())
+  name      String
+  adAccounts AdAccount[]
+  history   AccountClientHistory[]
+}
+
+model AdAccount {
+  id        Int       @id @default(autoincrement())
+  name      String
+  clientId  Int?
+  client    Client?   @relation(fields: [clientId], references: [id])
+  history   AccountClientHistory[]
+  fundings  AdAccountFunding[]
+  spends    Spend[]
+  invoices  Invoice[]
+}
+
+model AccountClientHistory {
+  id          Int       @id @default(autoincrement())
+  adAccount   AdAccount @relation(fields: [adAccountId], references: [id])
+  adAccountId Int
+  client      Client    @relation(fields: [clientId], references: [id])
+  clientId    Int
+  startDate   DateTime
+  endDate     DateTime?
+}
+
+model Bank {
+  id       Int           @id @default(autoincrement())
+  name     String
+  accounts BankAccount[]
+}
+
+model BankAccount {
+  id        Int      @id @default(autoincrement())
+  bank      Bank     @relation(fields: [bankId], references: [id])
+  bankId    Int
+  name      String
+  cards     Card[]
+  deposits  Deposit[]
+  transactions BankTransaction[]
+}
+
+model Card {
+  id             Int            @id @default(autoincrement())
+  bankAccount    BankAccount    @relation(fields: [bankAccountId], references: [id])
+  bankAccountId  Int
+  number         String
+  fundings       AdAccountFunding[]
+  statements     CardStatement[]
+  deposits       Deposit[]
+  transactions   CardTransaction[]
+}
+
+model AdAccountFunding {
+  id            Int        @id @default(autoincrement())
+  adAccount     AdAccount  @relation(fields: [adAccountId], references: [id])
+  adAccountId   Int
+  card          Card?      @relation(fields: [cardId], references: [id])
+  cardId        Int?
+  bankAccount   BankAccount? @relation(fields: [bankAccountId], references: [id])
+  bankAccountId Int?
+  startDate     DateTime
+  endDate       DateTime?
+}
+
+model Spend {
+  id          Int       @id @default(autoincrement())
+  adAccount   AdAccount @relation(fields: [adAccountId], references: [id])
+  adAccountId Int
+  date        DateTime
+  amount      Float
+  currency    String
+  reconciliations Reconciliation[]
+}
+
+model Deposit {
+  id          Int       @id @default(autoincrement())
+  card        Card?     @relation(fields: [cardId], references: [id])
+  cardId      Int?
+  bankAccount BankAccount? @relation(fields: [bankAccountId], references: [id])
+  bankAccountId Int?
+  date        DateTime
+  amount      Float
+  currency    String
+  reconciliations Reconciliation[]
+}
+
+model Invoice {
+  id          Int       @id @default(autoincrement())
+  adAccount   AdAccount @relation(fields: [adAccountId], references: [id])
+  adAccountId Int
+  date        DateTime
+  amount      Float
+  currency    String
+}
+
+model CardStatement {
+  id        Int       @id @default(autoincrement())
+  card      Card      @relation(fields: [cardId], references: [id])
+  cardId    Int
+  periodStart DateTime
+  periodEnd   DateTime
+  transactions CardTransaction[]
+}
+
+model CardTransaction {
+  id             Int       @id @default(autoincrement())
+  cardStatement  CardStatement @relation(fields: [cardStatementId], references: [id])
+  cardStatementId Int
+  date           DateTime
+  description    String
+  amount         Float
+  currency       String
+  reconciliation Reconciliation?
+}
+
+model BankTransaction {
+  id           Int        @id @default(autoincrement())
+  bankAccount  BankAccount @relation(fields: [bankAccountId], references: [id])
+  bankAccountId Int
+  date         DateTime
+  description  String
+  amount       Float
+  currency     String
+  reconciliation Reconciliation?
+}
+
+model Reconciliation {
+  id             Int       @id @default(autoincrement())
+  spend          Spend?    @relation(fields: [spendId], references: [id])
+  spendId        Int?
+  deposit        Deposit?  @relation(fields: [depositId], references: [id])
+  depositId      Int?
+  bankTransaction BankTransaction? @relation(fields: [bankTransactionId], references: [id])
+  bankTransactionId Int?
+  cardTransaction CardTransaction? @relation(fields: [cardTransactionId], references: [id])
+  cardTransactionId Int?
+  status        String
+}
+
+model FXRate {
+  id           Int      @id @default(autoincrement())
+  date         DateTime
+  fromCurrency String
+  toCurrency   String
+  rate         Float
+}
+
+model Setting {
+  id    Int    @id @default(autoincrement())
+  key   String @unique
+  value String
+}
+
+model JobLog {
+  id      Int      @id @default(autoincrement())
+  jobName String
+  runAt   DateTime @default(now())
+  status  String
+  message String?
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,79 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const password = await bcrypt.hash('password', 10);
+  const user = await prisma.user.create({
+    data: { email: 'admin@example.com', password }
+  });
+
+  const clientA = await prisma.client.create({ data: { name: 'Client A' } });
+  const clientB = await prisma.client.create({ data: { name: 'Client B' } });
+
+  const ad1 = await prisma.adAccount.create({ data: { name: 'AdAccount 1', clientId: clientA.id } });
+  const ad2 = await prisma.adAccount.create({ data: { name: 'AdAccount 2', clientId: clientA.id } });
+  const ad3 = await prisma.adAccount.create({ data: { name: 'AdAccount 3', clientId: clientB.id } });
+
+  // History for ad1 switching from clientA to clientB mid month
+  const start = new Date('2024-01-01');
+  const mid = new Date('2024-01-15');
+  await prisma.accountClientHistory.createMany({
+    data: [
+      { adAccountId: ad1.id, clientId: clientA.id, startDate: start, endDate: mid },
+      { adAccountId: ad1.id, clientId: clientB.id, startDate: mid, endDate: null },
+    ],
+  });
+
+  // Bank, accounts, cards
+  const bank = await prisma.bank.create({ data: { name: 'Bank' } });
+  const bankAccount = await prisma.bankAccount.create({ data: { name: 'Main Account', bankId: bank.id } });
+  const card1 = await prisma.card.create({ data: { number: '1111', bankAccountId: bankAccount.id } });
+  const card2 = await prisma.card.create({ data: { number: '2222', bankAccountId: bankAccount.id } });
+
+  // Funding history for ad1 changing card mid cycle
+  const cardSwitch = new Date('2024-01-20');
+  await prisma.adAccountFunding.createMany({
+    data: [
+      { adAccountId: ad1.id, cardId: card1.id, startDate: start, endDate: cardSwitch },
+      { adAccountId: ad1.id, cardId: card2.id, startDate: cardSwitch, endDate: null },
+    ],
+  });
+
+  // Spends
+  await prisma.spend.createMany({
+    data: [
+      { adAccountId: ad1.id, date: new Date('2024-01-10'), amount: 100, currency: 'USD' },
+      { adAccountId: ad1.id, date: new Date('2024-01-18'), amount: 2000000, currency: 'VND' },
+      { adAccountId: ad1.id, date: new Date('2024-01-25'), amount: 150, currency: 'USD' },
+    ],
+  });
+
+  // Deposits
+  await prisma.deposit.createMany({
+    data: [
+      { cardId: card1.id, date: new Date('2024-01-09'), amount: 100, currency: 'USD' },
+      { cardId: card2.id, date: new Date('2024-01-22'), amount: 200, currency: 'USD' },
+    ],
+  });
+
+  // FX Rates
+  await prisma.fXRate.createMany({
+    data: [
+      { date: new Date('2024-01-01'), fromCurrency: 'USD', toCurrency: 'VND', rate: 23500 },
+      { date: new Date('2024-01-15'), fromCurrency: 'USD', toCurrency: 'VND', rate: 23600 },
+    ],
+  });
+
+  console.log('Seed complete');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold offline Next.js app router project with Tailwind CSS, shadcn/ui components, and Prisma ORM
- add JWT auth endpoints and CRUD APIs for clients and ad accounts
- include comprehensive Prisma schema and seed script with demo data

## Testing
- ❌ `npm test` (missing script)


------
https://chatgpt.com/codex/tasks/task_e_68ad42f71d9483268831cd4d76db7a7f