### PR TITLE
feat: add prisma schema

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./prisma/dev.db"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+prisma/dev.db

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "1",
+  "version": "1.0.0",
+  "description": "Khởi tạo repo để dùng với ChatGPT Codex.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,205 @@
+// Prisma schema file
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+enum UserRole {
+  ADMIN
+  USER
+}
+
+enum AdAccountStatus {
+  ACTIVE
+  INACTIVE
+  SUSPENDED
+}
+
+enum TransactionType {
+  DEBIT
+  CREDIT
+}
+
+enum ReconcileScope {
+  ACCOUNT
+  CARD
+  BANK
+}
+
+model User {
+  id        Int       @id @default(autoincrement())
+  email     String    @unique
+  name      String?
+  role      UserRole  @default(USER)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model Client {
+  id        Int        @id @default(autoincrement())
+  name      String
+  accounts  AdAccount[]
+  invoices  Invoice[]
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+}
+
+model AdAccount {
+  id         Int               @id @default(autoincrement())
+  platformId String            @unique
+  status     AdAccountStatus   @default(ACTIVE)
+  client     Client?           @relation(fields: [clientId], references: [id])
+  clientId   Int?
+  history    AccountClientHistory[]
+  fundings   AdAccountFunding[]
+  spends     Spend[]
+  createdAt  DateTime          @default(now())
+  updatedAt  DateTime          @updatedAt
+}
+
+model AccountClientHistory {
+  id          Int       @id @default(autoincrement())
+  adAccount   AdAccount @relation(fields: [adAccountId], references: [id])
+  adAccountId Int
+  client      Client    @relation(fields: [clientId], references: [id])
+  clientId    Int
+  start       DateTime
+  end         DateTime?
+  @@unique([adAccountId, clientId, start])
+}
+
+model Bank {
+  id        Int            @id @default(autoincrement())
+  name      String
+  accounts  BankAccount[]
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+}
+
+model BankAccount {
+  id            Int             @id @default(autoincrement())
+  bank          Bank            @relation(fields: [bankId], references: [id])
+  bankId        Int
+  accountNumber String
+  currency      String
+  cards         Card[]
+  transactions  BankTransaction[]
+  deposits      Deposit[]
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+  @@unique([bankId, accountNumber])
+}
+
+model Card {
+  id            Int             @id @default(autoincrement())
+  bankAccount   BankAccount?    @relation(fields: [bankAccountId], references: [id])
+  bankAccountId Int?
+  last4         String
+  fundings      AdAccountFunding[]
+  statements    CardStatement[]
+  transactions  CardTransaction[]
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+}
+
+model AdAccountFunding {
+  id           Int          @id @default(autoincrement())
+  adAccount    AdAccount    @relation(fields: [adAccountId], references: [id])
+  adAccountId  Int
+  bankAccount  BankAccount? @relation(fields: [bankAccountId], references: [id])
+  bankAccountId Int?
+  card         Card?        @relation(fields: [cardId], references: [id])
+  cardId       Int?
+  start        DateTime
+  end          DateTime?
+  @@unique([adAccountId, start])
+}
+
+model Spend {
+  id         Int       @id @default(autoincrement())
+  adAccount  AdAccount @relation(fields: [adAccountId], references: [id])
+  adAccountId Int
+  amount     Decimal   @db.Decimal(18, 2)
+  date       DateTime
+}
+
+model Deposit {
+  id           Int          @id @default(autoincrement())
+  bankAccount  BankAccount  @relation(fields: [bankAccountId], references: [id])
+  bankAccountId Int
+  amount       Decimal       @db.Decimal(18, 2)
+  date         DateTime
+}
+
+model Invoice {
+  id        Int       @id @default(autoincrement())
+  client    Client    @relation(fields: [clientId], references: [id])
+  clientId  Int
+  amount    Decimal   @db.Decimal(18, 2)
+  issuedAt  DateTime
+}
+
+model CardStatement {
+  id          Int       @id @default(autoincrement())
+  card        Card      @relation(fields: [cardId], references: [id])
+  cardId      Int
+  periodStart DateTime
+  periodEnd   DateTime
+  transactions CardTransaction[]
+}
+
+model CardTransaction {
+  id           Int           @id @default(autoincrement())
+  card         Card          @relation(fields: [cardId], references: [id])
+  cardId       Int
+  statement    CardStatement? @relation(fields: [statementId], references: [id])
+  statementId  Int?
+  type         TransactionType
+  amount       Decimal        @db.Decimal(18, 2)
+  date         DateTime
+}
+
+model BankTransaction {
+  id            Int             @id @default(autoincrement())
+  bankAccount   BankAccount     @relation(fields: [bankAccountId], references: [id])
+  bankAccountId Int
+  type          TransactionType
+  amount        Decimal          @db.Decimal(18, 2)
+  date          DateTime
+}
+
+model Reconciliation {
+  id        Int           @id @default(autoincrement())
+  scope     ReconcileScope
+  reference String?
+  createdAt DateTime       @default(now())
+}
+
+model FXRate {
+  id           Int       @id @default(autoincrement())
+  fromCurrency String
+  toCurrency   String
+  rate         Float
+  date         DateTime
+  @@unique([fromCurrency, toCurrency, date])
+}
+
+model Setting {
+  id     Int    @id @default(autoincrement())
+  key    String @unique
+  value  String
+}
+
+model JobLog {
+  id        Int       @id @default(autoincrement())
+  jobName   String
+  ranAt     DateTime
+  success   Boolean
+  message   String?
+}
+


### PR DESCRIPTION
## Summary
- add Prisma schema with user, account, funding and transaction models
- configure SQLite datasource and enums for roles, statuses, transactions and reconciliation scopes
- include composite unique indexes for historical and funding records

## Testing
- `npx prisma migrate dev --name init` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68ad42fc09148326ba3c7800536c2ac4