### PR TITLE
Add basic JWT auth routes and middleware

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,45 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+
+export type Role = 'ADMIN' | 'ACCOUNTANT' | 'VIEWER';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+export async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, 10);
+}
+
+export async function verifyPassword(password: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(password, hash);
+}
+
+export interface JwtPayload {
+  username: string;
+  role: Role;
+}
+
+export function issueJwt(payload: JwtPayload): string {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: '1d' });
+}
+
+export function verifyJwt(token: string): JwtPayload | null {
+  try {
+    return jwt.verify(token, JWT_SECRET) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function requireRole(roles: Role[], handler: NextApiHandler): NextApiHandler {
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    const token = req.cookies['token'];
+    if (!token) return res.status(401).json({ message: 'Unauthorized' });
+    const payload = verifyJwt(token);
+    if (!payload || !roles.includes(payload.role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    (req as any).user = payload;
+    return handler(req, res);
+  };
+}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,0 +1,17 @@
+import type { Role } from './auth';
+
+export interface User {
+  username: string;
+  passwordHash: string;
+  role: Role;
+}
+
+const users = new Map<string, User>();
+
+export function addUser(user: User) {
+  users.set(user.username, user);
+}
+
+export function getUser(username: string) {
+  return users.get(username);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyJwt, Role } from './lib/auth';
+
+const roleMap: { prefix: string; role: Role }[] = [
+  { prefix: '/api/admin', role: 'ADMIN' },
+  { prefix: '/api/accountant', role: 'ACCOUNTANT' },
+  { prefix: '/api', role: 'VIEWER' },
+];
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  if (pathname.startsWith('/api/auth')) {
+    return NextResponse.next();
+  }
+
+  const token = req.cookies.get('token')?.value;
+  if (!token) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const payload = verifyJwt(token);
+  if (!payload) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  for (const { prefix, role } of roleMap) {
+    if (pathname.startsWith(prefix) && !hasRole(payload.role, role)) {
+      return new NextResponse('Forbidden', { status: 403 });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+function hasRole(userRole: Role, required: Role) {
+  const hierarchy: Role[] = ['VIEWER', 'ACCOUNTANT', 'ADMIN'];
+  return hierarchy.indexOf(userRole) >= hierarchy.indexOf(required);
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ad-finance-manager",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "tsc --noEmit"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/node": "^20.0.0",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/bcryptjs": "^2.4.2"
+  }
+}

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { issueJwt, verifyPassword } from '../../../lib/auth';
+import { getUser } from '../../../lib/users';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const { username, password } = req.body as { username?: string; password?: string };
+
+  if (!username || !password) {
+    return res.status(400).json({ message: 'Missing fields' });
+  }
+
+  const user = getUser(username);
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const valid = await verifyPassword(password, user.passwordHash);
+  if (!valid) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const token = issueJwt({ username, role: user.role });
+  res.setHeader('Set-Cookie', `token=${token}; HttpOnly; Path=/; Max-Age=86400`);
+  return res.status(200).json({ message: 'Logged in' });
+}

--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  res.setHeader('Set-Cookie', 'token=; HttpOnly; Path=/; Max-Age=0');
+  return res.status(200).json({ message: 'Logged out' });
+}

--- a/pages/api/auth/register.ts
+++ b/pages/api/auth/register.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { hashPassword, Role } from '../../../lib/auth';
+import { addUser, getUser } from '../../../lib/users';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const { username, password, role } = req.body as { username?: string; password?: string; role?: Role };
+
+  if (!username || !password || !role) {
+    return res.status(400).json({ message: 'Missing fields' });
+  }
+
+  if (getUser(username)) {
+    return res.status(409).json({ message: 'User exists' });
+  }
+
+  const passwordHash = await hashPassword(password);
+  addUser({ username, passwordHash, role });
+
+  return res.status(201).json({ message: 'Registered' });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  },
+  "include": ["lib/**/*", "pages/**/*", "middleware.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add bcrypt-based password hashing and JWT helpers
- create register/login/logout API routes issuing HttpOnly cookies
- add middleware enforcing JWT auth with role hierarchy

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbcryptjs)*
- `npm test` *(fails: tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad42fca8fc8326b6c0bd55552d0086